### PR TITLE
relay-hooks 1.1.0 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -868,6 +868,11 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@restart/hooks": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.1.tgz",
+      "integrity": "sha512-kjGGlli8iTe5TFDw6qHZJ5QK1naITMveIO+o8yQJJqwX8VIkiQzLddK98Lduga2krJMzWlNqDR/4isGLiyBlUA=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -2376,7 +2381,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2394,11 +2400,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2411,15 +2419,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2522,7 +2533,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2532,6 +2544,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2544,17 +2557,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2571,6 +2587,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2643,7 +2660,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2653,6 +2671,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2728,7 +2747,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2758,6 +2778,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2775,6 +2796,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2813,11 +2835,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -4440,9 +4464,12 @@
       }
     },
     "relay-hooks": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/relay-hooks/-/relay-hooks-0.3.0.tgz",
-      "integrity": "sha512-BmLWotYN/GKOfSGIrYF4dOnyTr3xEqYjs8Yc5pTa/akqclqhEQfnw/5EvJ5XjMBUevQwpEoTeAjFFNkqDFZ4Rg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/relay-hooks/-/relay-hooks-1.1.0.tgz",
+      "integrity": "sha512-1LXZl53VgkzItmWA6IyswY86M0CGHSJSPRYfWiEbnQehnwmfoD9tSPeMNtUxIVJFpGNbjhlvQp89EfH9BmDzGQ==",
+      "requires": {
+        "@restart/hooks": "^0.3.1"
+      }
     },
     "relay-runtime": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-relay": "^4.0.0",
     "react-relay-network-modern": "^4.0.0",
     "relay-compiler": "^4.0.0",
-    "relay-hooks": "^0.3.0",
+    "relay-hooks": "1.1.0",
     "relay-runtime": "^4.0.0",
     "webpack": "^4.34.0",
     "webpack-cli": "^3.3.4"

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -3,7 +3,7 @@ import ReactDOMServer from 'react-dom/server';
 import { QueryRenderer, graphql } from 'react-relay';
 import { Environment, RecordSource, Store } from 'relay-runtime';
 import { RelayNetworkLayer } from 'react-relay-network-modern/lib';
-import { useQuery } from "relay-hooks";
+import { useQuery, RelayEnvironmentProvider } from "relay-hooks";
 
 const network = new RelayNetworkLayer([
   next => async req => {
@@ -40,18 +40,22 @@ const Example = () => {
   );
 };
 
+const sourceHooks = new RecordSource();
+const storeHooks = new Store(sourceHooks);
+const environmentHooks = new Environment({ network, store: storeHooks });
+
 const HooksExample = () => {
   console.log('########## with hooks NetworkLayer invocation');
   const result = useQuery({
-    environment,
     query,
     variables,
   });
 
-  console.log('########## with hooks result');
-  console.log(result);
+  console.log('########## with hooks result', result);
+  
   return null;
 };
 
 ReactDOMServer.renderToString(<Example />);
-ReactDOMServer.renderToString(<HooksExample />);
+ReactDOMServer.renderToString(<RelayEnvironmentProvider environment={environmentHooks} >
+  <HooksExample /></RelayEnvironmentProvider>);


### PR DESCRIPTION
hi jazblueful,
I have adapted the project to version 1.1.0 of relay-hooks.
I also had to create another environment because running the same query twice relay keeps it in cache and is not re-executed in the network :)

In version 1.0.0 I added RelayEnvironmentProvider to meet the official react-relay version.
Now you can see that the network is running :)

I advise you to look at the sample project in relay-hooks, now it runs the server side rendering.

Let me know.
Lorenzo